### PR TITLE
1. As a user, I want to navigate to the homepage of lists by clicking directly on the logo 

### DIFF
--- a/src/components/authenticated/AuthenticatedNavBar.tsx
+++ b/src/components/authenticated/AuthenticatedNavBar.tsx
@@ -15,7 +15,11 @@ export function AuthenticatedNavBar() {
 			className="bg-secondary rounded-bottom-3 pt-0"
 		>
 			<Container className="align-items-center justify-content-evenly">
-				<Navbar.Brand className="bg-primary rounded-bottom-3 text-center mb-3 px-3 text-dark fw-bolder shadow">
+				<Navbar.Brand
+					as={NavLink}
+					to="/"
+					className="bg-primary rounded-bottom-3 text-center mb-3 px-3 text-dark fw-bolder shadow"
+				>
 					GrocerEase
 				</Navbar.Brand>
 				<Navbar.Toggle aria-controls="basic-navbar-nav" />

--- a/src/components/unauthenticated/UnauthenticatedNavBar.tsx
+++ b/src/components/unauthenticated/UnauthenticatedNavBar.tsx
@@ -14,7 +14,11 @@ export function UnauthenticatedNavBar() {
 			className="bg-secondary rounded-bottom-3 pt-0"
 		>
 			<Container>
-				<Navbar.Brand className="bg-primary rounded-bottom-3 text-center mb-3 px-3 text-dark fw-bolder shadow">
+				<Navbar.Brand
+					as={NavLink}
+					to="/"
+					className="bg-primary rounded-bottom-3 text-center mb-3 px-3 text-dark fw-bolder shadow"
+				>
 					GrocerEase
 				</Navbar.Brand>
 				<Navbar.Toggle aria-controls="basic-navbar-nav" />


### PR DESCRIPTION
## Description

This change focus on the **user experience** of navigating between pages of GrocerEase. Before the user had to use the hamburger menu to navigate back to the list of lists. Now, the user is able to simply click the "GrocerEase" logo and access their full created lists with a simple click one button, reducing the number of steps. 

This change continued the consistency of using React Router Navigation, with the NavLink component, providing the added benefit of client side navigation and still allowing for our React Bootstrap styling. 

## Related Issue

closes #1 

## Acceptance Criteria

- [ ] The user is able to access the list page by clicking on the "GrocerEase" NavBar logo from every page.
- [ ] This will be accomplished using the NavLink component from react-router-dom

## Type of Changes

'enhacement'

## Updates

### Before

https://github.com/user-attachments/assets/89a4f10c-bb56-4dda-9693-7ea9ed675102

### After

https://github.com/user-attachments/assets/f462d716-1da1-49c3-a2b3-b4e7a6ed2d95

## Testing Steps / QA Criteria

1. Navigate to different pages on GrocerEase
2. On each page, click the logo to navigate back to page of lists
3. Home page navigation will work on both unauthenticated and authenticated pages

